### PR TITLE
fix clock_gettime on darwin

### DIFF
--- a/m4/libev.m4
+++ b/m4/libev.m4
@@ -7,7 +7,12 @@ AC_CHECK_HEADERS(sys/inotify.h sys/epoll.h sys/event.h port.h poll.h sys/select.
 
 AC_CHECK_FUNCS(inotify_init epoll_ctl kqueue port_create poll eventfd signalfd)
 
-AC_CHECK_FUNCS(clock_gettime, [], [
+AC_CHECK_FUNCS(clock_gettime, [
+   if test $(uname) = Darwin; then
+      AC_MSG_NOTICE([Fixing incorrectly detected clock_gettime on Darwin])
+      AC_DEFINE(HAVE_CLOCK_GETTIME, 0, Define to 1 to use clock_gettime)
+   fi
+   ], [
    dnl on linux, try syscall wrapper first
    if test $(uname) = Linux; then
       AC_MSG_CHECKING(for clock_gettime syscall)


### PR DESCRIPTION
clock_gettime is defined with a weak reference on MacOSX 10.12, so if you build for older platforms using 10.12 you get either runtime or link errors.